### PR TITLE
Clean logging, remove compile dependency to Logback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,11 +43,9 @@ val refinedVersion = "0.9.10"
 val pureConfigVersion = "0.12.1"
 val scalacheckShapelessVersion = "1.1.8"
 val refinedScalacheckVersion = "0.9.10"
-val protobufJavaVersion = "3.8.0"
-val typesafeConfigVersion = "1.4.0"
 val logbackVersion = "1.2.3"
 val circeVersion = "0.12.2"
-val scalaLoggingVersion = "3.9.2"
+val slf4jApiVersion = "1.7.28"
 val kindProjectorVersion = "0.10.3"
 val betterMonadicForVersion = "0.3.1"
 
@@ -58,16 +56,15 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
   "com.typesafe.akka" %% "akka-remote" % akkaVersion,
-  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
-  "ch.qos.logback" % "logback-classic" % logbackVersion,
-  "com.typesafe" % "config" % typesafeConfigVersion,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
   "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % Test
 )
 
 // Logging
 libraryDependencies ++= Seq(
-  "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion
+  "org.slf4j" % "slf4j-api" % slf4jApiVersion,
+  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Test,
+  "ch.qos.logback" % "logback-classic" % logbackVersion % Test
 )
 
 // PureConfig

--- a/src/main/scala/com/swissborg/lithium/strategy/StaticQuorum.scala
+++ b/src/main/scala/com/swissborg/lithium/strategy/StaticQuorum.scala
@@ -6,10 +6,10 @@ import akka.cluster.MemberStatus.{Leaving, Up}
 import cats.effect.Sync
 import cats.implicits._
 import com.swissborg.lithium.implicits._
-import com.typesafe.scalalogging.StrictLogging
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric._
 import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric._
+import org.slf4j.LoggerFactory
 
 /**
  * Split-brain resolver strategy that will keep the partition that have a quorum (`config.quorumSize`) and down the other
@@ -18,11 +18,11 @@ import eu.timepit.refined.auto._
  *
  * This strategy is useful when the cluster has a fixed size.
  */
-private[lithium] class StaticQuorum[F[_]](config: StaticQuorum.Config)(implicit val F: Sync[F])
-    extends Strategy[F]
-    with StrictLogging {
+private[lithium] class StaticQuorum[F[_]](config: StaticQuorum.Config)(implicit val F: Sync[F]) extends Strategy[F] {
 
   import config._
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   override def takeDecision(worldView: WorldView): F[Decision] = {
     val nbrOfConsideredNonICNodes = worldView.nonICNodesWithRole(role).count { n =>

--- a/src/multi-jvm/resources/logback.xml
+++ b/src/multi-jvm/resources/logback.xml
@@ -1,18 +1,13 @@
 <configuration>
-    <property name="GENERAL_LOG_LEVEL" value="${GENERAL_LOG_LEVEL:-INFO}"/>
-    <property name="APPLICATION_LOG_LEVEL" value="${APPLICATION_LOG_LEVEL:-DEBUG}"/>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level- %msg%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %msg%n</pattern>
         </encoder>
     </appender>
 
-    <logger name="com.swissborg.lithium.resolver.SplitBrainResolver" level="${APPLICATION_LOG_LEVEL}"/>
-    <logger name="com.swissborg.lithium.reporter.SplitBrainReporter" level="${APPLICATION_LOG_LEVEL}"/>
-    <logger name="com.swissborg.lithium.reachability.ReachabilityReporter" level="${APPLICATION_LOG_LEVEL}"/>
+    <logger name="com.swissborg.lithium" level="DEBUG"/>
 
-    <root level="${GENERAL_LOG_LEVEL}">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
The sl4j-api is only required for a single log in `StaticQuorum`.

`multi-jvm:test` is passing.