### PR TITLE
fix: use systemActorOf rather than actorOf

### DIFF
--- a/src/main/scala/com/swissborg/lithium/internals/ClusterInternals.scala
+++ b/src/main/scala/com/swissborg/lithium/internals/ClusterInternals.scala
@@ -10,7 +10,7 @@ import akka.cluster.swissborg.ClusterInternalsPublisher
  */
 private[lithium] object ClusterInternals extends ExtensionId[ClusterInternalsImpl] with ExtensionIdProvider {
   override def createExtension(system: ExtendedActorSystem): ClusterInternalsImpl = {
-    system.actorOf(ClusterInternalsPublisher.props)
+    system.systemActorOf(ClusterInternalsPublisher.props, "cluster_internals")
     new ClusterInternalsImpl(system)
   }
 


### PR DESCRIPTION
actorOf doesn't work for typed actor systems, so replacing it with systemActorOf is desired solution like [here]( https://github.com/akka/akka/pull/26780). The only thing here is what name should be used for this actor.